### PR TITLE
.env file should be optional

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -61,10 +61,13 @@ func readProcfile() error {
 	return nil
 }
 
-// read .env file and set environments.
+// read .env file (if exists) and set environments.
 func readEnvfile() error {
 	content, err := ioutil.ReadFile(".env")
 	if err != nil {
+		if os.IsNotExist(err){
+			return nil
+		}
 		return err
 	}
 	for _, line := range strings.Split(string(content), "\n") {


### PR DESCRIPTION
foreman doesn't _require_ a .env file; without this file, goreman simply
fails:

``` bash
$ goreman start
open .env: no such file or directory
```

nice job on the port, btw ... goreman launches faster than foreman!
