### PR TITLE
Swap in dedicated .env handling library

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/joho/godotenv"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -62,25 +63,6 @@ func readProcfile() error {
 	return nil
 }
 
-// read .env file (if exists) and set environments.
-func readEnvfile() error {
-	content, err := ioutil.ReadFile(".env")
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	for _, line := range strings.Split(string(content), "\n") {
-		tokens := strings.SplitN(line, "=", 2)
-		if len(tokens) == 2 && tokens[0][0] != '#' {
-			k, v := strings.TrimSpace(tokens[0]), strings.TrimSpace(tokens[1])
-			os.Setenv(k, v)
-		}
-	}
-	return nil
-}
-
 // default port
 func defaultPort() uint {
 	s := os.Getenv("GOREMAN_RPC_PORT")
@@ -126,7 +108,7 @@ func start() error {
 		}
 		procs = tmp
 	}
-	err = readEnvfile()
+	err = godotenv.Load()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi @mattn,

I hope this isn't too forward - but I've swapped out your .env handling code for a call to a dedicated .env library that I wrote.

Given that the original ruby dotenv library was taken out of foreman, and then foreman relies on it I thought it might be good to do the same thing with the Go versions of both libraries.

I've got a pretty decent set of tests at https://github.com/joho/godotenv/blob/master/godotenv_test.go so this should up the robustness of .env handling for goreman users.
