### PR TITLE
Label argument for run commands as [PROCESS...]

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -19,12 +19,12 @@ const version = "0.0.6"
 
 func usage() {
 	fmt.Fprint(os.Stderr, `Tasks:
-  goreman check                  # Show entries in Procfile
-  goreman help [TASK]            # Show this help
-  goreman run COMMAND [ARGS...]  # Run a command
-                                   (start/stop/restart/list/status)
-  goreman start [PROCESS]        # Start the application
-  goreman version                # Display Goreman version
+  goreman check                     # Show entries in Procfile
+  goreman help [TASK]               # Show this help
+  goreman run COMMAND [PROCESS...]  # Run a command
+                                      (start/stop/restart/list/status)
+  goreman start [PROCESS]           # Start the application
+  goreman version                   # Display Goreman version
 
 Options:
 `)


### PR DESCRIPTION
Run commands that take arguments (start, stop and restart) all
take a process name as an argument.

If you do not provide a valid process, you get error such as
"Unknown proc: .."