### PR TITLE
Do not ignore baseport from config if given

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -107,8 +107,8 @@ func readProcfile(cfg *config) error {
 				return "%" + s[1:] + "%"
 			})
 		}
-		procs[k] = &procInfo{k, v, false, nil, *baseport}
-		*baseport++
+		procs[k] = &procInfo{k, v, false, nil, cfg.BasePort}
+		cfg.BasePort++
 		if len(k) > maxProcNameLength {
 			maxProcNameLength = len(k)
 		}


### PR DESCRIPTION
If `baseport` is set in `.goreman` file, it should be used. Currently it defaults to port `5000` or to flag.