### PR TITLE
fix process termination when /bin/sh is BusyBox

### DIFF
--- a/proc_posix.go
+++ b/proc_posix.go
@@ -13,7 +13,7 @@ import (
 func spawnProc(proc string) bool {
 	logger := createLogger(proc)
 
-	cs := []string{"/bin/sh", "-c", procs[proc].cmdline}
+	cs := []string{"/bin/sh", "-c", "exec " + procs[proc].cmdline}
 	cmd := exec.Command(cs[0], cs[1:]...)
 	cmd.Stdin = nil
 	cmd.Stdout = logger


### PR DESCRIPTION
It seems like bash is using `exec` by default for single commands provided via `-c`. BusyBox however is not. If `/bin/sh` is BusyBox (e.g. on Docker images based on Alpine) then the specified command becomes a subprocess of `/bin/sh`. This messes up signal handling and goreman fails to terminate the subprocesses when receiving a SIGTERM. Adding an explicit `exec` should fix this without modifying any command parsing.