### PR TITLE
Forward input signal instead of always sending SIGHUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ https://github.com/ddollar/foreman
 
     goreman start
 
+Will start all commands defined in the `Procfile` and display their outputs.
+Any signals are forwarded to the processes.
+
 ## Example
 
 See `eg` directory

--- a/proc_posix.go
+++ b/proc_posix.go
@@ -40,7 +40,7 @@ func spawnProc(proc string) bool {
 	return procs[proc].quit
 }
 
-func terminateProc(proc string) error {
+func terminateProc(proc string, signal os.Signal) error {
 	p := procs[proc].cmd.Process
 	if p == nil {
 		return nil
@@ -61,5 +61,5 @@ func terminateProc(proc string) error {
 	if err != nil {
 		return err
 	}
-	return target.Signal(syscall.SIGHUP)
+	return target.Signal(signal)
 }

--- a/proc_windows.go
+++ b/proc_windows.go
@@ -40,7 +40,7 @@ func spawnProc(proc string) bool {
 	return procs[proc].quit
 }
 
-func terminateProc(proc string) error {
+func terminateProc(proc string, signal os.Signal) error {
 	dll, err := syscall.LoadDLL("kernel32.dll")
 	if err != nil {
 		return err

--- a/rpc.go
+++ b/rpc.go
@@ -32,7 +32,7 @@ func (r *Goreman) Stop(args []string, ret *string) (err error) {
 		}
 	}()
 	for _, arg := range args {
-		if err = stopProc(arg, false); err != nil {
+		if err = stopProc(arg, false, nil); err != nil {
 			break
 		}
 	}
@@ -47,7 +47,7 @@ func (r *Goreman) StopAll(args []string, ret *string) (err error) {
 		}
 	}()
 	for proc := range procs {
-		if err = stopProc(proc, false); err != nil {
+		if err = stopProc(proc, false, nil); err != nil {
 			break
 		}
 	}


### PR DESCRIPTION
Goreman should forward the signal that it received, not always send SIGHUP.
If it wants to stop a process because e.g. `goreman stop` was run, it should use SIGTERM.