### PR TITLE
Use the same ports as foreman

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -123,7 +123,7 @@ func readProcfile(cfg *config) error {
 		p := &procInfo{proc: k, cmdline: v, port: cfg.BasePort}
 		p.cond = sync.NewCond(&p.mu)
 		procs[k] = p
-		cfg.BasePort++
+		cfg.BasePort += 100
 		if len(k) > maxProcNameLength {
 			maxProcNameLength = len(k)
 		}


### PR DESCRIPTION
In the original foreman the base port increases by 100 for each process type, then 1 for each concurrent process. goreman doesn't have concurrency, but it would be nice for the starting ports of each process type to be the same at least.

When I run `foreman start` with a `Procfile`:

```
web: ...
api: ...
```

I get something like:

```
11:44:54 web.1 | started with pid 123
11:44:54 api.1 | started with pid 124
11:44:54 web.1 | listening on port 5000
11:44:54 api.1 | listening on port 5100
...
```

In goreman:

```
11:44:54 web | Starting web on port 5000
11:44:54 api | Starting api on port 5001
11:44:54 web | listening on port 5000
11:44:54 api | listening on port 5001
...
```

If I compose these services using their ports and my team mates are still using foreman it means we have different ports and have to adjust them somehow, but neither foreman nor goreman tell us which ports are used by which services, and I don't want to run a service registry inside my Procfile — stable ports are enough.

After this change:

```
11:44:54 web | Starting web on port 5000
11:44:54 api | Starting api on port 5100
11:44:54 web | listening on port 5000
11:44:54 api | listening on port 5100
...
```