### PR TITLE
Reduce line-splitting

### DIFF
--- a/log.go
+++ b/log.go
@@ -63,7 +63,12 @@ func (l *clogger) writeLines() {
 				line, err := buf.ReadBytes('\n')
 				if len(line) > 0 {
 					if line[len(line)-1] == '\n' {
-						l.writeBuffers(line)
+						// any text followed by a newline should flush
+						// existing buffers. a bare newline should flush
+						// existing buffers, but only if there are any.
+						if len(line) != 1 || len(l.buffers) > 0 {
+							l.writeBuffers(line)
+						}
 						tick = nil
 					} else {
 						l.buffers = append(l.buffers, line)

--- a/log.go
+++ b/log.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -10,8 +12,12 @@ import (
 )
 
 type clogger struct {
-	idx  int
-	proc string
+	idx     int
+	proc    string
+	writes  chan []byte
+	done    chan struct{}
+	timeout time.Duration // how long to wait before printing partial lines
+	buffers net.Buffers   // partial lines awaiting printing
 }
 
 var colors = []ct.Color{
@@ -26,33 +32,63 @@ var ci int
 
 var mutex = new(sync.Mutex)
 
+// write any stored buffers, plus the given line, then empty out
+// the buffers.
+func (l *clogger) writeBuffers(line []byte) {
+	now := time.Now().Format("15:04:05")
+	mutex.Lock()
+	ct.ChangeColor(colors[l.idx], false, ct.None, false)
+	fmt.Printf("%s %*s | ", now, maxProcNameLength, l.proc)
+	ct.ResetColor()
+	l.buffers = append(l.buffers, line)
+	l.buffers.WriteTo(os.Stdout)
+	l.buffers = l.buffers[0:0]
+	mutex.Unlock()
+}
+
+// bundle writes into lines, waiting briefly for completion of lines
+func (l *clogger) writeLines() {
+	var tick <-chan time.Time
+	for {
+		select {
+		case w, ok := <-l.writes:
+			if !ok {
+				if len(l.buffers) > 0 {
+					l.writeBuffers([]byte("\n"))
+				}
+				return
+			}
+			buf := bytes.NewBuffer(w)
+			for {
+				line, err := buf.ReadBytes('\n')
+				if len(line) > 0 {
+					if line[len(line)-1] == '\n' {
+						l.writeBuffers(line)
+						tick = nil
+					} else {
+						l.buffers = append(l.buffers, line)
+						tick = time.After(l.timeout)
+					}
+				}
+				if err != nil {
+					break
+				}
+			}
+			l.done <- struct{}{}
+		case <-tick:
+			if len(l.buffers) > 0 {
+				l.writeBuffers([]byte("\n"))
+			}
+			tick = nil
+		}
+	}
+
+}
+
 // write handler of logger.
 func (l *clogger) Write(p []byte) (int, error) {
-	buf := bytes.NewBuffer(p)
-	wrote := 0
-	for {
-		line, err := buf.ReadBytes('\n')
-		if len(line) > 1 {
-			now := time.Now().Format("15:04:05")
-			format := fmt.Sprintf("%%s %%%ds | ", maxProcNameLength)
-			s := string(line)
-
-			mutex.Lock()
-			ct.ChangeColor(colors[l.idx], false, ct.None, false)
-			fmt.Printf(format, now, l.proc)
-			ct.ResetColor()
-			fmt.Print(s)
-			mutex.Unlock()
-
-			wrote += len(line)
-		}
-		if err != nil {
-			break
-		}
-	}
-	if len(p) > 0 && p[len(p)-1] != '\n' {
-		fmt.Println()
-	}
+	l.writes <- p
+	<-l.done
 	return len(p), nil
 }
 
@@ -60,7 +96,8 @@ func (l *clogger) Write(p []byte) (int, error) {
 func createLogger(proc string) *clogger {
 	mutex.Lock()
 	defer mutex.Unlock()
-	l := &clogger{ci, proc}
+	l := &clogger{idx: ci, proc: proc, writes: make(chan []byte), done: make(chan struct{}), timeout: 2 * time.Millisecond}
+	go l.writeLines()
 	ci++
 	if ci >= len(colors) {
 		ci = 0


### PR DESCRIPTION
Unix makes roughly zero guarantees about when it will or won't
split or coalesce writes across pipes, which means that a single
write of a sentence of text could result in two separate calls
to the Write() method of an io.Writer used as Stdout or Stderr
for a command.

The least-bad solution, I think, is to have a separate goroutine
which waits for full lines, but will also time out after a bit
so that incomplete lines don't get lost forever, just delayed
very slightly (about a millisecond seems to cover everything).

Typical output change:

	09:13:02               web | npm
	09:13:02               web |  WARN
	09:13:02               web |  bootstrap@4.0.0 [...]

becomes:

	09:14:05               web | npm WARN bootstrap@4.0.0 [...]

This also addresses a subtle bug where single-byte non-newline
writes were getting discarded, but producing blank lines with
no header information.

As a secondary issue, instead of remaking the format string
for every message, we use a generic format string with a
length argument, since the format string never changes except
for that length.