### PR TITLE
Remove 'quit' attribute

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -50,7 +50,6 @@ Options:
 type procInfo struct {
 	proc       string
 	cmdline    string
-	quit       bool
 	cmd        *exec.Cmd
 	port       uint
 	colorIndex int

--- a/proc.go
+++ b/proc.go
@@ -11,9 +11,9 @@ import (
 
 var wg sync.WaitGroup
 
-// stop specified proc.
-// if signal is nil, SIGTERM is used
-func stopProc(proc string, quit bool, signal os.Signal) error {
+// Stop the specified proc, issuing SIGKILL if it does not terminate within 10
+// seconds. If signal is nil, SIGTERM is used.
+func stopProc(proc string, signal os.Signal) error {
 	if signal == nil {
 		signal = syscall.SIGTERM
 	}
@@ -29,7 +29,6 @@ func stopProc(proc string, quit bool, signal os.Signal) error {
 		return nil
 	}
 
-	p.quit = quit
 	err := terminateProc(proc, signal)
 	if err != nil {
 		return err
@@ -76,7 +75,7 @@ func restartProc(proc string) error {
 		return errors.New("unknown proc: " + proc)
 	}
 
-	stopProc(proc, false, nil)
+	stopProc(proc, nil)
 	return startProc(proc)
 }
 
@@ -93,7 +92,7 @@ func startProcs() error {
 	signal.Notify(sc, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 	signal := <-sc
 	for proc := range procs {
-		stopProc(proc, true, signal)
+		stopProc(proc, signal)
 	}
 	return nil
 }

--- a/proc_posix.go
+++ b/proc_posix.go
@@ -12,7 +12,7 @@ import (
 )
 
 // spawn command that specified as proc.
-func spawnProc(proc string) bool {
+func spawnProc(proc string) {
 	procObj := procs[proc]
 	logger := createLogger(proc, procObj.colorIndex)
 
@@ -28,10 +28,9 @@ func spawnProc(proc string) bool {
 	err := cmd.Start()
 	if err != nil {
 		fmt.Fprintf(logger, "Failed to start %s: %s\n", proc, err)
-		return true
+		return
 	}
 	procObj.cmd = cmd
-	procObj.quit = true
 	procObj.mu.Unlock()
 	err = cmd.Wait()
 	procObj.mu.Lock()
@@ -39,8 +38,6 @@ func spawnProc(proc string) bool {
 	procObj.waitErr = err
 	procObj.cmd = nil
 	fmt.Fprintf(logger, "Terminating %s\n", proc)
-
-	return procObj.quit
 }
 
 func terminateProc(proc string, signal os.Signal) error {

--- a/proc_windows.go
+++ b/proc_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // spawn command that specified as proc.
-func spawnProc(proc string) bool {
+func spawnProc(proc string) {
 	procObj := procs[proc]
 	logger := createLogger(proc, procObj.colorIndex)
 
@@ -26,10 +26,9 @@ func spawnProc(proc string) bool {
 	err := cmd.Start()
 	if err != nil {
 		fmt.Fprintf(logger, "Failed to start %s: %s\n", proc, err)
-		return true
+		return
 	}
 	procObj.cmd = cmd
-	procObj.quit = true
 	procObj.mu.Unlock()
 	err = cmd.Wait()
 	procObj.mu.Lock()
@@ -37,8 +36,6 @@ func spawnProc(proc string) bool {
 	procObj.waitErr = err
 	procObj.cmd = nil
 	fmt.Fprintf(logger, "Terminating %s\n", proc)
-
-	return procs[proc].quit
 }
 
 func terminateProc(proc string, signal os.Signal) error {

--- a/rpc.go
+++ b/rpc.go
@@ -36,7 +36,7 @@ func (r *Goreman) Stop(args []string, ret *string) (err error) {
 		}
 	}()
 	for _, arg := range args {
-		if err = stopProc(arg, false, nil); err != nil {
+		if err = stopProc(arg, nil); err != nil {
 			break
 		}
 	}
@@ -51,7 +51,7 @@ func (r *Goreman) StopAll(args []string, ret *string) (err error) {
 		}
 	}()
 	for proc := range procs {
-		if err = stopProc(proc, false, nil); err != nil {
+		if err = stopProc(proc, nil); err != nil {
 			break
 		}
 	}


### PR DESCRIPTION
It's set in a few places but it's never read by anything, and removing
it can simplify the API significantly.

This work was sponsored by [Sourcegraph](https://sourcegraph.com).