### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+go_import_path: github.com/mattn/goreman
+
+os: linux
+dist: trusty
+sudo: false
+
+before_script:
+  - go get ./...
+
+script:
+  - go test ./...
+  - GOOS=windows go test ./...
+
+go:
+  - 1.10.x
+  - 1.11.x
+  - master
+
+cache:
+  directories:
+    - $GOPATH/pkg


### PR DESCRIPTION
The primary benefit of this is by building both Linux and Windows
machines, we test all of the code paths and ensure we're not checking
in incompatible code.

It would be good to add tests at some point but for the moment it's
a good idea to build the code for each GOOS before merging.

This work was sponsored by [Sourcegraph](https://sourcegraph.com).