### PR TITLE
Add basic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_script:
 
 script:
   - go test ./...
-  - GOOS=windows go test ./...
 
 go:
   - 1.10.x

--- a/goreman_test.go
+++ b/goreman_test.go
@@ -1,0 +1,62 @@
+// Windows doesn't have sleep.exe which we use for making the subprocesses stay
+// alive for a certain amount of time.
+
+// +build !windows
+
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func startGoreman(ctx context.Context, t *testing.T, ch <-chan os.Signal, file []byte) {
+	t.Helper()
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(file); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config{
+		Procfile: f.Name(),
+	}
+	if ch == nil {
+		ch = notifyCh()
+	}
+	if err := start(ctx, ch, cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGoreman(t *testing.T) {
+	var file = []byte(`
+web1: sleep 0.1
+web2: sleep 0.1
+web3: sleep 0.1
+web4: sleep 0.1
+`)
+	startGoreman(context.TODO(), t, nil, file)
+}
+
+func TestGoremanSignal(t *testing.T) {
+	var file = []byte(`
+web1: sleep 10
+web2: sleep 10
+web3: sleep 10
+web4: sleep 10
+`)
+	now := time.Now()
+	sc := make(chan os.Signal, 1)
+	go func() {
+		sc <- os.Interrupt
+	}()
+	startGoreman(context.TODO(), t, sc, file)
+	if dur := time.Since(now); dur > 50*time.Millisecond {
+		t.Errorf("test took too much time; should have canceled after 10ms, got %s", dur)
+	}
+}

--- a/proc.go
+++ b/proc.go
@@ -92,7 +92,7 @@ func stopProcs(sig os.Signal) error {
 }
 
 // spawn all procs.
-func startProcs() error {
+func startProcs(sc <-chan os.Signal) error {
 	for proc := range procs {
 		startProc(proc)
 	}
@@ -101,7 +101,6 @@ func startProcs() error {
 		wg.Wait()
 		allProcsDone <- struct{}{}
 	}()
-	sc := notifyCh()
 	for {
 		select {
 		// TODO: add more events here.


### PR DESCRIPTION
These two tests check that we can start processes with goreman and
then send signals to them to terminate them.

Refactor startProc to accept the signal as an external argument, which
allows us to send incoming signals directly from the test.

Change the Travis CI configuration to just build the Windows config,
not actually test it, this fails now since we actually have tests that
can run.