### PR TITLE
Allow process to exit on error

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -21,7 +21,7 @@ func (r *Goreman) Start(args []string, ret *string) (err error) {
 		}
 	}()
 	for _, arg := range args {
-		if err = startProc(arg); err != nil {
+		if err = startProc(arg, nil); err != nil {
 			break
 		}
 	}


### PR DESCRIPTION
Add a command line flag where if a subprocess exits with an error, the
parent process can terminate all other processes and then exit. Add
logic to distinguish this case - where a subprocess anomalously exits
- and the case where a process is shut down by the supervisor.