### PR TITLE
Add flag to avoid showing timestamp in log

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -82,6 +82,9 @@ var setPorts = flag.Bool("set-ports", true, "False to avoid setting PORT env var
 // true to exit the supervisor
 var exitOnError = flag.Bool("exit-on-error", false, "Exit goreman if a subprocess quits with a nonzero return code")
 
+// show timestamp in log
+var logTime = flag.Bool("logtime", true, "show timestamp in log")
+
 var maxProcNameLength = 0
 
 var re = regexp.MustCompile(`\$([a-zA-Z]+[a-zA-Z0-9_]+)`)

--- a/log.go
+++ b/log.go
@@ -61,10 +61,14 @@ func (v *buffers) WriteTo(w io.Writer) (n int64, err error) {
 // write any stored buffers, plus the given line, then empty out
 // the buffers.
 func (l *clogger) writeBuffers(line []byte) {
-	now := time.Now().Format("15:04:05")
 	mutex.Lock()
 	fmt.Fprintf(out, "\x1b[%dm", colors[l.idx])
-	fmt.Fprintf(out, "%s %*s | ", now, maxProcNameLength, l.proc)
+	if *logTime {
+		now := time.Now().Format("15:04:05")
+		fmt.Fprintf(out, "%s %*s | ", now, maxProcNameLength, l.proc)
+	} else {
+		fmt.Fprintf(out, "%*s | ", maxProcNameLength, l.proc)
+	}
 	fmt.Fprintf(out, "\x1b[m")
 	l.buffers = append(l.buffers, line)
 	l.buffers.WriteTo(out)


### PR DESCRIPTION
**Pull-request use cases**
Sometime it can be useful to not show timestamp in logs.
I have at least 2 use cases for that:

1) I'm using goreman to start a system made of multiple applications, each application already logs its own timestamp, in that case having 2 timestamps per line takes up some screen space without adding value.

2) Another somewhat more contrived example :) I'm still using goreman to start a system made of multiple applications. Each app logs on standard output.
After an important refactoring on all apps (it's an embedded system), I'd like to check the overall system behavior by diff'ing the merged log output produced by goreman, with the merged log before the refactoring took place.
In that case timestamp just get in the way of the diff.


**Pull-request description**
The current default behavior is unchanged. When adding the global `-no-time` flag, `clogger` simply skips logging the timestamp.