### PR TITLE
Go vet fixes

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -210,6 +210,9 @@ func start(ctx context.Context, sig <-chan os.Signal, cfg *config) error {
 		return err
 	}
 	ctx, cancel := context.WithCancel(ctx)
+	// Cancel the RPC server when procs have returned/errored, cancel the
+	// context anyway in case of early return.
+	defer cancel()
 	if len(cfg.Args) > 1 {
 		tmp := make(map[string]*procInfo, len(cfg.Args[1:]))
 		maxProcNameLength = 0
@@ -229,7 +232,6 @@ func start(ctx context.Context, sig <-chan os.Signal, cfg *config) error {
 	rpcChan := make(chan *rpcMessage, 10)
 	go startServer(ctx, rpcChan, cfg.Port)
 	procsErr := startProcs(sig, rpcChan, cfg.ExitOnError)
-	cancel() // If procs have returned/errored, cancel the RPC server.
 	return procsErr
 }
 

--- a/proc.go
+++ b/proc.go
@@ -178,5 +178,4 @@ func startProcs(sc <-chan os.Signal, rpcCh <-chan *rpcMessage, exitOnError bool)
 			return stopProcs(sig)
 		}
 	}
-	return nil
 }


### PR DESCRIPTION
Running `go vet` on the project produces:
```
# github.com/mattn/goreman
./goreman.go:212:2: the cancel function is not used on all paths (possible context leak)
./goreman.go:219:5: this return statement may be reached without using the cancel var defined on line 212
./proc.go:181:2: unreachable code
```
This pull-request fixes that.