### PR TITLE
Fix version command by setting version on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 builds:
   - binary: goreman
+    ldflags:
+      - -X main.version={{.Version}}
     goos:
       - windows
       - darwin

--- a/goreman.go
+++ b/goreman.go
@@ -19,7 +19,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const version = "0.2.1"
+// version is the git tag at the time of build and is used to denote the
+// binary's current version. This value is supplied as an ldflag at compile
+// time by goreleaser (see .goreleaser.yml).
+var version = "dev"
 
 func usage() {
 	fmt.Fprint(os.Stderr, `Tasks:


### PR DESCRIPTION
The output of `goreman version` doesn't match the latest released
version (according to the git tags).

This changes the `version` in the code to be set dynamically by
goreleaser when a new release is made.

What do you think?

Do you even still use goreleaser?