### PR TITLE
Add exit-on-stop flag

### DIFF
--- a/goreman.go
+++ b/goreman.go
@@ -91,6 +91,9 @@ var setPorts = flag.Bool("set-ports", true, "False to avoid setting PORT env var
 // true to exit the supervisor
 var exitOnError = flag.Bool("exit-on-error", false, "Exit goreman if a subprocess quits with a nonzero return code")
 
+// true to exit the supervisor when all processes stop
+var exitOnStop = flag.Bool("exit-on-stop", true, "Exit goreman if all subprocesses stop")
+
 // show timestamp in log
 var logTime = flag.Bool("logtime", true, "show timestamp in log")
 

--- a/proc.go
+++ b/proc.go
@@ -145,10 +145,12 @@ func startProcs(sc <-chan os.Signal, rpcCh <-chan *rpcMessage, exitOnError bool)
 	}
 
 	allProcsDone := make(chan struct{}, 1)
-	go func() {
-		wg.Wait()
-		allProcsDone <- struct{}{}
-	}()
+	if *exitOnStop {
+		go func() {
+			wg.Wait()
+			allProcsDone <- struct{}{}
+		}()
+	}
 	for {
 		select {
 		case rpcMsg := <-rpcCh:


### PR DESCRIPTION
This makes it possible to keep the server running when all processes stop. This is useful if you want to start the server in the background, and only control it with RPCs