### PR TITLE
Proposal for updated install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://github.com/ddollar/foreman
 ## Getting Started
 
     go install github.com/mattn/goreman@latest
-    
+
 ## Usage
 
     goreman start

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ https://github.com/ddollar/foreman
 
 ## Getting Started
 
-    go get github.com/mattn/goreman
-
+    go install github.com/mattn/goreman@latest
+    
 ## Usage
 
     goreman start


### PR DESCRIPTION
```
λ. go get github.com/mattn/goreman

go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.


λ. go install github.com/mattn/goreman

go install: version is required when current directory is not in a module
	Try 'go install github.com/mattn/goreman@latest' to install the latest version
```