### PR TITLE
.github: test using latest Go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,16 +5,19 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.13.x', '1.18.x' ]
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: ${{ matrix.go }}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Test
       run: go test -v -race ./...


### PR DESCRIPTION
I'm assuming Go 1.13 is there for backward compatibility, so test that
version as well as the most recent version.