### PR TITLE
main: add option to disable RPC server

### DIFF
--- a/_example/web.go
+++ b/_example/web.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ var procfile = flag.String("f", "Procfile", "proc file")
 // rpc port number.
 var port = flag.Uint("p", defaultPort(), "port")
 
+var startRPCServer = flag.Bool("rpc-server", true, "Start an RPC server listening on "+defaultAddr())
+
 // base directory
 var basedir = flag.String("basedir", "", "base directory")
 
@@ -264,7 +266,9 @@ func start(ctx context.Context, sig <-chan os.Signal, cfg *config) error {
 	}
 	godotenv.Load()
 	rpcChan := make(chan *rpcMessage, 10)
-	go startServer(ctx, rpcChan, cfg.Port)
+	if *startRPCServer {
+		go startServer(ctx, rpcChan, cfg.Port)
+	}
 	procsErr := startProcs(sig, rpcChan, cfg.ExitOnError)
 	return procsErr
 }

--- a/proc_posix.go
+++ b/proc_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main


### PR DESCRIPTION
By default, goreman opens a port to the outside world that can
accept commands, which could lead to potentially bad or unexpected
consequences. (Also, my Mac asks me to approve the connection every
single time I start goreman).

Also add new-style build tags.