### PR TITLE
Update dependencies

### DIFF
--- a/export.go
+++ b/export.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,7 +24,7 @@ func exportUpstart(cfg *config, path string) error {
 		if err != nil {
 			return err
 		}
-		b, err := ioutil.ReadFile(filepath.Join(filepath.Dir(procfile), ".env"))
+		b, err := os.ReadFile(filepath.Join(filepath.Dir(procfile), ".env"))
 		if err == nil {
 			for _, line := range strings.Split(string(b), "\n") {
 				token := strings.SplitN(line, "=", 2)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/mattn/goreman
 
-go 1.13
+go 1.17
 
 require (
 	github.com/joho/godotenv v1.4.0
 	github.com/mattn/go-colorable v0.1.12
-	golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d
+	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,9 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 h1:8IVLkfbr2cLhv0a/vKq4UFUcJym8RmDoDboxCFWEjYE=
-golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4kVNokFwDDyWh/3rGY+I=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/goreman_test.go
+++ b/goreman_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,13 +22,13 @@ func TestMain(m *testing.M) {
 		}
 
 		code := `package main;import ("os";"strconv";"time");func main(){i,_:=strconv.ParseFloat(os.Args[1]);time.Sleep(time.Duration(i)*time.Second)}`
-		dir, err := ioutil.TempDir("", "goreman-test")
+		dir, err := os.MkdirTemp("", "goreman-test")
 		if err != nil {
 			panic(err)
 		}
 		sleep = filepath.Join(dir, "sleep.exe")
 		src := filepath.Join(dir, "sleep.go")
-		err = ioutil.WriteFile(src, []byte(code), 0644)
+		err = os.WriteFile(src, []byte(code), 0644)
 		if err != nil {
 			panic(err)
 		}
@@ -51,7 +50,7 @@ func TestMain(m *testing.M) {
 
 func startGoreman(ctx context.Context, t *testing.T, ch <-chan os.Signal, file []byte) error {
 	t.Helper()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -129,7 +128,7 @@ func readConfig() *config {
 	cfg.ExitOnError = *exitOnError
 	cfg.Args = flag.Args()
 
-	b, err := ioutil.ReadFile(".goreman")
+	b, err := os.ReadFile(".goreman")
 	if err == nil {
 		yaml.Unmarshal(b, &cfg)
 	}
@@ -138,7 +137,7 @@ func readConfig() *config {
 
 // read Procfile and parse it.
 func readProcfile(cfg *config) error {
-	content, err := ioutil.ReadFile(cfg.Procfile)
+	content, err := os.ReadFile(cfg.Procfile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR updates library dependencies (possibly fixes crash on malicious yaml file due to https://github.com/go-yaml/yaml/releases/tag/v3.0.1), also migrates from deprecated `io/ioutil` package.