### PR TITLE
Spawned procs should inherit goreman's stdin

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -16,7 +16,7 @@ func spawnProc(name string, errCh chan<- error) {
 
 	cs := append(cmdStart, proc.cmdline)
 	cmd := exec.Command(cs[0], cs[1:]...)
-	cmd.Stdin = nil
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = logger
 	cmd.Stderr = logger
 	cmd.SysProcAttr = procAttrs


### PR DESCRIPTION
Processes spawned via `foreman` inherit stdin from it. You can test this like so:

```
❯ cat Procfile
web: echo "Hello, $(read user; echo $user)"

❯ foreman start
23:16:12 web.1  | started with pid 91492
cora
23:16:14 web.1  | Hello, cora
23:16:15 web.1  | exited with code 0
23:16:15 system | sending SIGTERM to all processes
```

Why does this matter? Because some things care if stdin is a TTY or `/dev/null` (the previous stdin value for all launched procs):

```
❯ cora-goreman start watch
23:19:17 watch | Starting watch on port 5000
23:19:17 watch | > dev
23:19:17 watch | > npx tailwindcss -i ./app/assets/stylesheets/engine/tailwind-input.css -o ./app/assets/builds/tailwind.css --watch
23:19:18 watch | Rebuilding...
23:19:18 watch | Done in 167ms.
^C23:19:31 watch | Terminating watch

❯ /opt/homebrew/bin/goreman start watch
23:20:35 watch | Starting watch on port 5000
23:20:35 watch | > dev
23:20:35 watch | > npx tailwindcss -i ./app/assets/stylesheets/engine/tailwind-input.css -o ./app/assets/builds/tailwind.css --watch
23:20:35 watch | Terminating watch
```

You could always redirect `/dev/null` into your processes if that's what you want but forcing them to inherit your terminal's TTY is impossible if goreman is inserting `/dev/null` as stdin and so I think this is the better default.

Thoughts?