### PR TITLE
Add support for running sub-processes under a PTY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/mattn/go-isatty v0.0.17 // indirect
+require (
+	github.com/creack/pty v1.1.18
+	github.com/mattn/go-isatty v0.0.17 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/main.go
+++ b/main.go
@@ -98,6 +98,9 @@ var exitOnStop = flag.Bool("exit-on-stop", true, "Exit goreman if all subprocess
 // show timestamp in log
 var logTime = flag.Bool("logtime", true, "show timestamp in log")
 
+// use a PTY for all subprocesses
+var usePty = flag.Bool("pty", false, "use a PTY for all subprocesses (noop on Windows)")
+
 var maxProcNameLength = 0
 
 var re = regexp.MustCompile(`\$([a-zA-Z]+[a-zA-Z0-9_]+)`)

--- a/proc_windows.go
+++ b/proc_windows.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 
@@ -62,4 +63,10 @@ func notifyCh() <-chan os.Signal {
 	sc := make(chan os.Signal, 10)
 	signal.Notify(sc, os.Interrupt)
 	return sc
+}
+
+// This is a no-op on Windows.
+func startPTY(logger *clogger, cmd *exec.Cmd) error {
+	cmd.Stdout = logger
+	cmd.Stderr = logger
 }


### PR DESCRIPTION
This is really nice for running programs that output colour, such as coloured log lines, etc.

I defaulted it to off because some applications when run under a PTY will attempt to move the cursor around, clear lines, and so on, so it should be up to the user to decide whether to enable it.