### PR TITLE
Fix env var substitution regex

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ var logTime = flag.Bool("logtime", true, "show timestamp in log")
 
 var maxProcNameLength = 0
 
-var re = regexp.MustCompile(`\$([a-zA-Z]+[a-zA-Z0-9_]+)`)
+var re = regexp.MustCompile(`\$([a-zA-Z_][a-zA-Z0-9_]*)`)
 
 type config struct {
 	Procfile string `yaml:"procfile"`


### PR DESCRIPTION
The $VAR to %VAR% conversion on Windows required at least 2 chars and rejected leading underscores. Accept $A and $_FOO.