### PR TITLE
Fix data race in Status RPC

### DIFF
--- a/goreman_test.go
+++ b/goreman_test.go
@@ -134,6 +134,30 @@ web4: sleep 10
 	}
 }
 
+func TestGoremanStatusRace(t *testing.T) {
+	var file = []byte(`
+web1: sleep 0.2
+`)
+	done := make(chan struct{}, 1)
+	go func() {
+		startGoreman(context.TODO(), t, nil, file)
+		done <- struct{}{}
+	}()
+	gm := &Goreman{}
+	for {
+		select {
+		case <-done:
+			return
+		default:
+			var ret string
+			if err := gm.Status(nil, &ret); err != nil {
+				t.Error(err)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
 func TestGoremanStopProcDoesntStopOtherProcs(t *testing.T) {
 	var file = []byte(`
 web1: sleep 10

--- a/rpc.go
+++ b/rpc.go
@@ -120,9 +120,16 @@ func (r *Goreman) Status(args []string, ret *string) (err error) {
 			err = r.(error)
 		}
 	}()
+	mu.Lock()
+	ps := make([]*procInfo, len(procs))
+	copy(ps, procs)
+	mu.Unlock()
 	*ret = ""
-	for _, proc := range procs {
-		if proc.cmd != nil {
+	for _, proc := range ps {
+		proc.mu.Lock()
+		running := proc.cmd != nil
+		proc.mu.Unlock()
+		if running {
 			*ret += "*" + proc.name + "\n"
 		} else {
 			*ret += " " + proc.name + "\n"


### PR DESCRIPTION
Status read procs and proc.cmd without locking, racing with readProcfile and spawnProc. Adds a test that fails under -race before the fix.