### PR TITLE
Close RPC listener on shutdown

### DIFF
--- a/goreman_test.go
+++ b/goreman_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -156,6 +158,35 @@ web1: sleep 0.2
 			time.Sleep(time.Millisecond)
 		}
 	}
+}
+
+func TestGoremanReleasesRPCPort(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("web1: sleep 0.1\n")); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config{
+		ExitOnError: true,
+		Procfile:    f.Name(),
+		Port:        18555,
+	}
+	if err := start(context.TODO(), notifyCh(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	addr := fmt.Sprintf("%s:%d", defaultAddr(), cfg.Port)
+	for i := 0; i < 100; i++ {
+		var ln net.Listener
+		ln, err = net.Listen("tcp", addr)
+		if err == nil {
+			ln.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("RPC port was not released after goreman stopped: %v", err)
 }
 
 func TestGoremanStopProcDoesntStopOtherProcs(t *testing.T) {

--- a/rpc.go
+++ b/rpc.go
@@ -179,6 +179,10 @@ func startServer(ctx context.Context, rpcChan chan<- *rpcMessage, listenPort uin
 	if err != nil {
 		return err
 	}
+	go func() {
+		<-ctx.Done()
+		server.Close()
+	}()
 	var wg sync.WaitGroup
 	var acceptingConns = true
 	for acceptingConns {


### PR DESCRIPTION
startServer never closed the listener, leaking the port and the Accept goroutine. Adds a test that the port is released.