### PR TITLE
Fix logger goroutine leak on restart

### DIFF
--- a/goreman_test.go
+++ b/goreman_test.go
@@ -189,6 +189,47 @@ func TestGoremanReleasesRPCPort(t *testing.T) {
 	t.Fatalf("RPC port was not released after goreman stopped: %v", err)
 }
 
+func TestGoremanRestartDoesntLeakGoroutines(t *testing.T) {
+	var file = []byte(`
+web1: sleep 10
+`)
+	sc := make(chan os.Signal, 1)
+	done := make(chan struct{}, 1)
+	go func() {
+		startGoreman(context.TODO(), t, sc, file)
+		done <- struct{}{}
+	}()
+	waitRunning := func() {
+		for {
+			proc := findProc("web1")
+			if proc != nil {
+				proc.mu.Lock()
+				cmd := proc.cmd
+				proc.mu.Unlock()
+				if cmd != nil && cmd.Process != nil {
+					return
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	waitRunning()
+	before := runtime.NumGoroutine()
+	for i := 0; i < 20; i++ {
+		if err := restartProc("web1"); err != nil {
+			t.Fatal(err)
+		}
+		waitRunning()
+	}
+	after := runtime.NumGoroutine()
+	t.Logf("goroutines: before=%d after=%d", before, after)
+	if after-before > 10 {
+		t.Errorf("restarting leaked goroutines: %d before, %d after", before, after)
+	}
+	sc <- os.Interrupt
+	<-done
+}
+
 func TestGoremanStopProcDoesntStopOtherProcs(t *testing.T) {
 	var file = []byte(`
 web1: sleep 10

--- a/main.go
+++ b/main.go
@@ -66,6 +66,10 @@ type procInfo struct {
 	mu      sync.Mutex
 	cond    *sync.Cond
 	waitErr error
+
+	// logger is created on first spawn and reused across restarts so that
+	// restarting a proc does not leak the logger goroutine.
+	logger *clogger
 }
 
 var mu sync.Mutex

--- a/proc.go
+++ b/proc.go
@@ -12,7 +12,11 @@ import (
 // spawnProc starts the specified proc, and returns any error from running it.
 func spawnProc(name string, errCh chan<- error) {
 	proc := findProc(name)
-	logger := createLogger(name, proc.colorIndex)
+	logger := proc.logger
+	if logger == nil {
+		logger = createLogger(name, proc.colorIndex)
+		proc.logger = logger
+	}
 
 	cs := append(cmdStart, proc.cmdline)
 	cmd := exec.Command(cs[0], cs[1:]...)


### PR DESCRIPTION
Each restart created a new clogger whose goroutine never exits. Reuse the logger stored in procInfo. Adds a leak regression test.