### PR TITLE
Parse .env with godotenv in export

### DIFF
--- a/export.go
+++ b/export.go
@@ -6,9 +6,22 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/joho/godotenv"
 )
 
 func exportUpstart(cfg *config, path string) error {
+	procfile, err := filepath.Abs(cfg.Procfile)
+	if err != nil {
+		return err
+	}
+	// parse .env the same way `goreman start` does (godotenv), so exported
+	// values match the runtime environment.
+	env, err := godotenv.Read(filepath.Join(filepath.Dir(procfile), ".env"))
+	if err != nil {
+		env = map[string]string{}
+	}
+
 	for _, proc := range procs {
 		f, err := os.Create(filepath.Join(path, "app-"+proc.name+".conf"))
 		if err != nil {
@@ -19,27 +32,6 @@ func exportUpstart(cfg *config, path string) error {
 		fmt.Fprintf(f, "stop on stopping app-%s\n", proc.name)
 		fmt.Fprintf(f, "respawn\n")
 		fmt.Fprintf(f, "\n")
-
-		env := map[string]string{}
-		procfile, err := filepath.Abs(cfg.Procfile)
-		if err != nil {
-			return err
-		}
-		b, err := os.ReadFile(filepath.Join(filepath.Dir(procfile), ".env"))
-		if err == nil {
-			for _, line := range strings.Split(string(b), "\n") {
-				token := strings.SplitN(line, "=", 2)
-				if len(token) != 2 {
-					continue
-				}
-				if strings.HasPrefix(token[0], "export ") {
-					token[0] = token[0][7:]
-				}
-				token[0] = strings.TrimSpace(token[0])
-				token[1] = strings.TrimSpace(token[1])
-				env[token[0]] = token[1]
-			}
-		}
 
 		if proc.setPort {
 			fmt.Fprintf(f, "env PORT=%d\n", proc.port)


### PR DESCRIPTION
The hand-rolled .env parser kept quotes in values, diverging from what godotenv provides at runtime. Use godotenv.Read.