### PR TITLE
Generate release notes when creating GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release
@@ -19,15 +22,6 @@ jobs:
     - name: Cross build
       run: make cross
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@master
+      run: gh release create "$GITHUB_REF_NAME" --title "Release $GITHUB_REF_NAME" --generate-notes goxz/*
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-    - name: Upload
-      run: make upload
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace the deprecated actions/create-release and the separate ghr upload step with a single gh release create call using --generate-notes, so releases include a changelog generated from merged PRs since the previous tag.